### PR TITLE
Make install location configurable

### DIFF
--- a/cookbooks/calico/attributes/default.rb
+++ b/cookbooks/calico/attributes/default.rb
@@ -2,3 +2,8 @@
 default["calico"]["admin_password"] = "abcdef"
 default["calico"]["admin_token"]    = "abcdef"
 
+# The location of the Calico packages, and the location of the key used to sign
+# them. By default we install from the release versions.
+default["calico"]["package_source"] = "http://binaries.projectcalico.org/repo ./"
+default["calico"]["package_key"]    = "http://binaries.projectcalico.org/repo/key"
+

--- a/cookbooks/calico/files/default/calico.list
+++ b/cookbooks/calico/files/default/calico.list
@@ -1,2 +1,0 @@
-deb http://binaries.projectcalico.org/repo ./
-

--- a/cookbooks/calico/files/default/preferences
+++ b/cookbooks/calico/files/default/preferences
@@ -1,4 +1,0 @@
-Package: *
-Pin: origin binaries.projectcalico.org
-Pin-Priority: 1001
-

--- a/cookbooks/calico/recipes/control.rb
+++ b/cookbooks/calico/recipes/control.rb
@@ -1,24 +1,32 @@
+require 'uri'
+
 # Find the BGP neighbors, which is everyone except ourselves.
 bgp_neighbors = search(:node, "role:compute").select { |n| n[:ipaddress] != node[:ipaddress] }
 
-cookbook_file "/etc/apt/sources.list.d/calico.list" do
+template "/etc/apt/sources.list.d/calico.list" do
     mode "0644"
-    source "calico.list"
+    source "calico.list.erb"
     owner "root"
     group "root"
+    variables({
+        package_source: node[:calico][:package_source],
+    })
     notifies :run, "execute[apt-key-calico]", :immediately
 end
 execute "apt-key-calico" do
     user "root"
-    command "curl -L http://binaries.projectcalico.org/repo/key | sudo apt-key add -"
+    command "curl -L #{node[:calico][:package_key]} | sudo apt-key add -"
     action :nothing
     notifies :run, "execute[apt-get update]", :immediately
 end
-cookbook_file "/etc/apt/preferences" do
+template "/etc/apt/preferences" do
     mode "0644"
-    source "preferences"
+    source "preferences.erb"
     owner "root"
     group "root"
+    variables({
+        package_host: URI.parse(node[:calico][:package_source].split[0]).host
+    })
 end
 
 # Install NTP.

--- a/cookbooks/calico/templates/default/calico.list.erb
+++ b/cookbooks/calico/templates/default/calico.list.erb
@@ -1,0 +1,1 @@
+deb <%= @package_source %>

--- a/cookbooks/calico/templates/default/preferences.erb
+++ b/cookbooks/calico/templates/default/preferences.erb
@@ -1,0 +1,3 @@
+Package: *
+Pin: origin <%= @package_host %>
+Pin-Priority: 1001


### PR DESCRIPTION
This pull request adds support for configuring the source of Calico packages. This makes it possible for users to provide locally-hosted Calico packages (in case they don't want to be at the bleeding edge), and makes it possible for us to use development versions from another source.

By default, we will continue to obtain packages from the release location.
