### PR TITLE
Start Felix and ACL Manager after creating their config, instead of restarting

### DIFF
--- a/cookbooks/calico/recipes/control.rb
+++ b/cookbooks/calico/recipes/control.rb
@@ -643,7 +643,6 @@ end
 
 service "calico-acl-manager" do
     provider Chef::Provider::Service::Upstart
-    supports :restart => true
     action [:nothing]
 end
 
@@ -652,5 +651,5 @@ template "/etc/calico/acl_manager.cfg" do
     source "control/acl_manager.cfg.erb"
     owner "root"
     group "root"
-    notifies :restart, "service[calico-acl-manager]", :immediately
+    notifies :start, "service[calico-acl-manager]", :immediately
 end

--- a/cookbooks/calico/recipes/general_compute.rb
+++ b/cookbooks/calico/recipes/general_compute.rb
@@ -210,7 +210,6 @@ end
 
 service "calico-felix" do
     provider Chef::Provider::Service::Upstart
-    supports :restart => true
     action [:nothing]
 end
 
@@ -222,5 +221,5 @@ template "/etc/calico/felix.cfg" do
     })
     owner "root"
     group "root"
-    notifies :restart, "service[calico-felix]", :immediately
+    notifies :start, "service[calico-felix]", :immediately
 end


### PR DESCRIPTION
This is the Chef part of https://github.com/Metaswitch/calico/issues/137