### PR TITLE
Modified BGP peer name in bird config templates to allow for long FQDNs.

### DIFF
--- a/cookbooks/calico/templates/default/compute/bird.conf.erb
+++ b/cookbooks/calico/templates/default/compute/bird.conf.erb
@@ -30,9 +30,9 @@ protocol direct {
 
 # Peer with all neighbours.
 <% @bgp_neighbors.each_with_index do |n, index| %>
-# <%= n[:fqdn].gsub(/[^0-9a-z]/i, '') %>
+# <%= n[:fqdn] %>
 protocol bgp <%= "peer#{index}" %> {
-  description <%= "\"BGP Connection to #{n[:fqdn].gsub(/[^0-9a-z]/i, '')}\"" %>;
+  description <%= "\"BGP Connection to #{n[:fqdn]}\"" %>;
   local as 64511;
   neighbor <%= n[:ipaddress] %> as 64511;
   multihop;

--- a/cookbooks/calico/templates/default/compute/bird.conf.erb
+++ b/cookbooks/calico/templates/default/compute/bird.conf.erb
@@ -29,9 +29,10 @@ protocol direct {
 }
 
 # Peer with all neighbours.
-<% @bgp_neighbors.each do |n| %>
-protocol bgp <%= n[:fqdn].gsub(/[^0-9a-z]/i, '') %> {
-  description "Connection to BGP route reflector";
+<% @bgp_neighbors.each_with_index do |n, index| %>
+# <%= n[:fqdn].gsub(/[^0-9a-z]/i, '') %>
+protocol bgp <%= "peer#{index}" %> {
+  description <%= "\"BGP Connection to #{n[:fqdn].gsub(/[^0-9a-z]/i, '')}\"" %>;
   local as 64511;
   neighbor <%= n[:ipaddress] %> as 64511;
   multihop;

--- a/cookbooks/calico/templates/default/compute/bird6.conf.erb
+++ b/cookbooks/calico/templates/default/compute/bird6.conf.erb
@@ -41,9 +41,9 @@ protocol direct {
 
 # Peer with all neighbours.
 <% @bgp_neighbors.each_with_index do |n, index| %>
-# <%= n[:fqdn].gsub(/[^0-9a-z]/i, '') %>
+# <%= n[:fqdn] %>
 protocol bgp <%= "peer#{index}" %> {
-  description <%= "\"BGP Connection to #{n[:fqdn].gsub(/[^0-9a-z]/i, '')}\"" %>;
+  description <%= "\"BGP Connection to #{n[:fqdn]}\"" %>;
   local as 64511;
   neighbor <%= n[:ip6address] %> as 64511;
   multihop;

--- a/cookbooks/calico/templates/default/compute/bird6.conf.erb
+++ b/cookbooks/calico/templates/default/compute/bird6.conf.erb
@@ -40,9 +40,10 @@ protocol direct {
 }
 
 # Peer with all neighbours.
-<% @bgp_neighbors.each do |n| %>
-protocol bgp <%= n[:fqdn].gsub(/[^0-9a-z]/i, '') %> {
-  description "Connection to BGP route reflector";
+<% @bgp_neighbors.each_with_index do |n, index| %>
+# <%= n[:fqdn].gsub(/[^0-9a-z]/i, '') %>
+protocol bgp <%= "peer#{index}" %> {
+  description <%= "\"BGP Connection to #{n[:fqdn].gsub(/[^0-9a-z]/i, '')}\"" %>;
   local as 64511;
   neighbor <%= n[:ip6address] %> as 64511;
   multihop;


### PR DESCRIPTION
BIRD places a limit on the length of the BGP protocol name, so don't use the FQDN, which
can be quite long.  Instead, include the FQDN in the description.
