### PR TITLE
Rlb setup passwordless logon

### DIFF
--- a/cookbooks/calico/files/default/config.ssh
+++ b/cookbooks/calico/files/default/config.ssh
@@ -1,0 +1,3 @@
+Host * 
+  StrictHostKeyChecking no 
+  UserKnownHostsFile=/dev/null 

--- a/cookbooks/calico/recipes/general_compute.rb
+++ b/cookbooks/calico/recipes/general_compute.rb
@@ -174,12 +174,16 @@ ruby_block "expose-public-key" do
 end
 
 # Add the public key for the other compute nodes to our authorized_keys.
-file = Chef::Util::FileEdit.new("/var/lib/nova/.ssh/authorized_keys")
-other_compute.each do |n|
-    key = n[:calico][:nova_public_key]
-    file.insert_line_if_no_match(/#{key}/, key)
+ruby_block "load-compute-node-keys" do
+    block do
+        file = Chef::Util::FileEdit.new("/var/lib/nova/.ssh/authorized_keys")
+        other_compute.each do |n|
+            key = n[:calico][:nova_public_key]
+            file.insert_line_if_no_match(/#{key}/, key)
+	end
+	file.write_file
+    end
 end
-file.write_file
 
 # NETWORKING
 

--- a/cookbooks/calico/recipes/general_compute.rb
+++ b/cookbooks/calico/recipes/general_compute.rb
@@ -166,6 +166,15 @@ file "/var/lib/nova/.ssh/authorized_keys" do
     action :create_if_missing
 end
 
+# Add SSH config to automatically accept unknown hosts
+cookbook_file "/var/lib/nova.ssh/config" do
+    source "config.ssh"
+    owner "nova"
+    group "nova"
+    mode "0600"
+    action :create
+end
+
 # Expose public key in attributes
 ruby_block "expose-public-key" do
     block do

--- a/cookbooks/calico/recipes/general_compute.rb
+++ b/cookbooks/calico/recipes/general_compute.rb
@@ -169,7 +169,7 @@ end
 # Expose public key in attributes
 ruby_block "expose-public-key" do
     block do
-        node.default["nova_public_key"] = ::File.read("/var/lib/nova/.ssh/id_rsa.pub")
+        node.default['nova_public_key'] = ::File.read("/var/lib/nova/.ssh/id_rsa.pub")
     end
 end
 
@@ -178,7 +178,7 @@ ruby_block "load-compute-node-keys" do
     block do
         file = Chef::Util::FileEdit.new("/var/lib/nova/.ssh/authorized_keys")
         other_compute.each do |n|
-            key = n.default["nova_public_key"]
+            key = n['nova_public_key']
             file.insert_line_if_no_match(/#{key}/, key)
 	end
 	file.write_file

--- a/cookbooks/calico/recipes/general_compute.rb
+++ b/cookbooks/calico/recipes/general_compute.rb
@@ -144,7 +144,9 @@ service "nova-api-metadata" do
     action [:nothing]
 end
 
-# Set up Nova passwordless authentication.
+# SET UP NOVA WITH PASSWORDLESS AUTHENTICATION
+
+# Provide a logon shell for nova user.
 execute "nova-logon-shell" do
     user "root"
     command "usermod -s /bin/bash nova"

--- a/cookbooks/calico/recipes/general_compute.rb
+++ b/cookbooks/calico/recipes/general_compute.rb
@@ -167,12 +167,11 @@ file "/var/lib/nova/.ssh/authorized_keys" do
 end
 
 # Add SSH config to automatically accept unknown hosts
-cookbook_file "/var/lib/nova.ssh/config" do
+cookbook_file "/var/lib/nova/.ssh/config" do
     source "config.ssh"
     owner "nova"
     group "nova"
     mode "0600"
-    action :create
 end
 
 # Expose public key in attributes

--- a/cookbooks/calico/recipes/general_compute.rb
+++ b/cookbooks/calico/recipes/general_compute.rb
@@ -169,7 +169,7 @@ end
 # Expose public key in attributes
 ruby_block "expose-public-key" do
     block do
-        node[:calico][:nova_public_key] = ::File.read("/var/lib/nova/.ssh/id_rsa.pub")
+        node.default["nova_public_key"] = ::File.read("/var/lib/nova/.ssh/id_rsa.pub")
     end
 end
 
@@ -178,7 +178,7 @@ ruby_block "load-compute-node-keys" do
     block do
         file = Chef::Util::FileEdit.new("/var/lib/nova/.ssh/authorized_keys")
         other_compute.each do |n|
-            key = n[:calico][:nova_public_key]
+            key = n.default["nova_public_key"]
             file.insert_line_if_no_match(/#{key}/, key)
 	end
 	file.write_file

--- a/cookbooks/calico/recipes/general_compute.rb
+++ b/cookbooks/calico/recipes/general_compute.rb
@@ -169,14 +169,14 @@ end
 # Expose public key in attributes
 ruby_block "expose-public-key" do
     block do
-        node.default['nova_public_key'] = ::File.read("/var/lib/nova/.ssh/id_rsa.pub")
+        node[:calico][:nova_public_key] = ::File.read("/var/lib/nova/.ssh/id_rsa.pub")
     end
 end
 
 # Add the public key for the other compute nodes to our authorized_keys.
-file = Chef::Util::FileEdit.("/var/lib/nova/.ssh/authorized_keys")
+file = Chef::Util::FileEdit.new("/var/lib/nova/.ssh/authorized_keys")
 other_compute.each do |n|
-    key = n.nova_public_key
+    key = n[:calico][:nova_public_key]
     file.insert_line_if_no_match(/#{key}/, key)
 end
 file.write_file


### PR DESCRIPTION
Adding creation of SSH keys and sharing of keys to allow passwordless access between compute nodes for the nova user.
