### PR TITLE
Don't configure use of RPC notification driver

### DIFF
--- a/cookbooks/calico/templates/default/compute/neutron.conf.erb
+++ b/cookbooks/calico/templates/default/compute/neutron.conf.erb
@@ -203,7 +203,7 @@ core_plugin = neutron.plugins.ml2.plugin.Ml2Plugin
 # Logging driver
 # notification_driver = neutron.openstack.common.notifier.log_notifier
 # RPC driver.
-notification_driver = neutron.openstack.common.notifier.rpc_notifier
+# notification_driver = neutron.openstack.common.notifier.rpc_notifier
 
 # default_notification_level is used to form actual topic name(s) or to set logging level
 # default_notification_level = INFO
@@ -474,4 +474,3 @@ service_provider=VPN:openswan:neutron.services.vpn.service_drivers.ipsec.IPsecVP
 # service_provider=VPN:cisco:neutron.services.vpn.service_drivers.cisco_ipsec.CiscoCsrIPsecVPNDriver:default
 # Uncomment the line below to use Embrane heleos as Load Balancer service provider.
 # service_provider=LOADBALANCER:Embrane:neutron.services.loadbalancer.drivers.embrane.driver.EmbraneLbaas:default
-

--- a/cookbooks/calico/templates/default/control/neutron.conf.erb
+++ b/cookbooks/calico/templates/default/control/neutron.conf.erb
@@ -203,7 +203,7 @@ allow_overlapping_ips = True
 # Logging driver
 # notification_driver = neutron.openstack.common.notifier.log_notifier
 # RPC driver.
-notification_driver = neutron.openstack.common.notifier.rpc_notifier
+# notification_driver = neutron.openstack.common.notifier.rpc_notifier
 
 # default_notification_level is used to form actual topic name(s) or to set logging level
 # default_notification_level = INFO
@@ -474,4 +474,3 @@ service_provider=VPN:openswan:neutron.services.vpn.service_drivers.ipsec.IPsecVP
 # service_provider=VPN:cisco:neutron.services.vpn.service_drivers.cisco_ipsec.CiscoCsrIPsecVPNDriver:default
 # Uncomment the line below to use Embrane heleos as Load Balancer service provider.
 # service_provider=LOADBALANCER:Embrane:neutron.services.loadbalancer.drivers.embrane.driver.EmbraneLbaas:default
-


### PR DESCRIPTION
If we do this, a queue of messages just builds up forever in RabbitMQ,
and nothing ever consumes those messages.
