### PR TITLE
Removed -listen-client-urls for etcd v2.0.11

### DIFF
--- a/cookbooks/calico/templates/default/compute/etcd.conf.erb
+++ b/cookbooks/calico/templates/default/compute/etcd.conf.erb
@@ -13,5 +13,4 @@ env ETCD_DATA_DIR=/var/lib/etcd
 export ETCD_DATA_DIR
 
 exec /usr/bin/etcd -proxy on                                                  \
-                   -listen-client-urls http://127.0.0.1:4001                  \
                    -initial-cluster <%= "#{@controller.gsub(/[^0-9a-z]/i, '')}=http://#{@controller_ip}:2380" %>


### PR DESCRIPTION
etcd 2.0.11 has changed expected command line parameters.  This updates
config to match what etcd now wants.
